### PR TITLE
Add FluidAudio to Vendor-Specific SDKs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Frameworks and runtimes designed for deploying models on edge devices.
 ### Vendor-Specific SDKs
 * [Qualcomm QNN](https://www.qualcomm.com/developer/software/qualcomm-ai-engine-direct-sdk) - Qualcomm AI Stack for Snapdragon NPUs/DSPs.
 * [Apple Core ML](https://developer.apple.com/documentation/coreml) - Framework to integrate ML models into iOS/macOS apps.
+* [FluidAudio](https://github.com/FluidInference/FluidAudio) - Local audio AI SDK for Apple platforms with ASR, speaker diarization, VAD, and TTS optimized for Apple Neural Engine.
 * [NVIDIA TensorRT](https://developer.nvidia.com/tensorrt) - SDK for high-performance deep learning inference on NVIDIA GPUs (including Jetson).
 * [Intel OpenVINO](https://github.com/openvinotoolkit/openvino) - Toolkit for optimizing and deploying AI inference on Intel hardware (CPU/GPU/NPU).
 * [MediaTek NeuroPilot](https://neuropilot.mediatek.com/) - AI ecosystem and SDK for MediaTek NPUs.


### PR DESCRIPTION
Adds [FluidAudio](https://github.com/FluidInference/FluidAudio) - a local audio AI SDK optimized for Apple Neural Engine.

FluidAudio provides on-device:
- Automatic Speech Recognition (ASR)
- Speaker Diarization
- Voice Activity Detection (VAD)
- Text-to-Speech (TTS)

Uses CoreML bundles for efficient inference on Apple silicon.