### PR TITLE
Add vimin-core — distributed local LLM/Whisper orchestration for multi-machine on-device inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Frameworks and runtimes designed for deploying models on edge devices.
 * [mllm](https://github.com/UbiquitousLearning/mllm) - A fast and lightweight LLM inference engine for mobile and edge devices.
 * [OmniInfer](https://github.com/omnimind-ai/OmniInfer-VLM) - High-performance, on-device VLM inference with hybrid NPU acceleration.
 * [RunAnywhere](https://github.com/RunanywhereAI/runanywhere-sdks) - Open-source SDK for running LLMs and multimodal models on-device across iOS, Android, and cross-platform apps.
+* [vimin-core](https://github.com/pberlizov/vimin-public) - Python library for orchestrating distributed local LLM and Whisper inference across up to 10 machines. MLX on Apple Silicon, llama.cpp on any platform. Designed for air-gapped and privacy-sensitive deployments. MIT.
 
 ### Vendor-Specific SDKs
 * [Qualcomm QNN](https://www.qualcomm.com/developer/software/qualcomm-ai-engine-direct-sdk) - Qualcomm AI Stack for Snapdragon NPUs/DSPs.


### PR DESCRIPTION
## Summary

[vimin-core](https://github.com/pberlizov/vimin-public) is a Python library for orchestrating distributed local LLM and Whisper inference across a fleet of up to 10 machines — with no cloud dependency.

**Why it fits this list:**
- Runs entirely on-device — no API calls, no telemetry
- MLX backend for Apple Silicon (ANE-accelerated), llama.cpp for any platform
- mlx-whisper on Apple Silicon, faster-whisper elsewhere
- Designed specifically for air-gapped networks and privacy-sensitive environments
- Coordinates multiple on-device nodes via broadcast or multi-step pipelines

**Install:**
```bash
pip install 'vimin-core[mlx]'      # Apple Silicon
pip install 'vimin-core[llamacpp]' # Any platform
```

MIT license. Added to the **LLM & GenAI Specialized** section under Inference Engines.