### PR TITLE
Add Off Grid (on-device mobile LLM runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Frameworks and runtimes designed for deploying models on edge devices.
 * [mllm](https://github.com/UbiquitousLearning/mllm) - A fast and lightweight LLM inference engine for mobile and edge devices.
 * [OmniInfer](https://github.com/omnimind-ai/OmniInfer-VLM) - High-performance, on-device VLM inference with hybrid NPU acceleration.
 * [RunAnywhere](https://github.com/RunanywhereAI/runanywhere-sdks) - Open-source SDK for running LLMs and multimodal models on-device across iOS, Android, and cross-platform apps.
+* [Off Grid](https://github.com/alichherawalla/off-grid-mobile-ai) - Open-source iOS/Android app running LLMs (Llama, Qwen, Gemma, Phi, DeepSeek) entirely on-device via llama.cpp. Includes voice (whisper.cpp), vision, on-device image generation, and tool calling.
 
 ### Vendor-Specific SDKs
 * [Qualcomm QNN](https://www.qualcomm.com/developer/software/qualcomm-ai-engine-direct-sdk) - Qualcomm AI Stack for Snapdragon NPUs/DSPs.


### PR DESCRIPTION
Adds [Off Grid](https://github.com/alichherawalla/off-grid-mobile-ai) to **Inference Engines > LLM & GenAI Specialized**.

Off Grid is a consumer iOS/Android app and runtime that ships llama.cpp + GGUF on real devices in production. Sits alongside the existing engines listed in this section (llama.cpp, MLC LLM, mllm, OmniInfer, RunAnywhere) — fits as the consumer-app-as-runtime entry.

- Open-source, MIT-licensed (1,785 stars)
- Runs Llama, Qwen, Gemma, Phi, DeepSeek
- Includes voice (whisper.cpp), vision, on-device image generation, and tool calling
- 100% offline, no account, no telemetry
- 10K+ Android installs

Happy to move it to a different section (e.g. a new "Mobile Apps" subsection) if you prefer — flag and I'll update the PR.